### PR TITLE
Number of result per query is limited to 50 by default to fix #13.

### DIFF
--- a/jmxtrans2-core/pom.xml
+++ b/jmxtrans2-core/pom.xml
@@ -121,6 +121,8 @@
                     <excludedClasses>
                         <!-- no need to test generated classes -->
                         <excludedClass>org.jmxtrans.core.config.jaxb.*</excludedClass>
+                        <!-- some problem on travis with this test, let's disable it until we understand better -->
+                        <excludedClass>org.jmxtrans.core.query.embedded.QueryTest</excludedClass>
                     </excludedClasses>
                 </configuration>
             </plugin>

--- a/jmxtrans2-core/pom.xml
+++ b/jmxtrans2-core/pom.xml
@@ -121,8 +121,6 @@
                     <excludedClasses>
                         <!-- no need to test generated classes -->
                         <excludedClass>org.jmxtrans.core.config.jaxb.*</excludedClass>
-                        <!-- some problem on travis with this test, let's disable it until we understand better -->
-                        <excludedClass>org.jmxtrans.core.query.embedded.QueryTest</excludedClass>
                     </excludedClasses>
                 </configuration>
             </plugin>

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/config/XmlConfigParser.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/config/XmlConfigParser.java
@@ -165,7 +165,8 @@ public class XmlConfigParser implements ConfigParser {
         for (QueryType query : queries.getQuery()) {
             Query.Builder queryBuilder = Query.builder()
                     .withObjectName(query.getObjectName())
-                    .withResultAlias(query.getResultAlias());
+                    .withResultAlias(query.getResultAlias())
+                    .withMaxResults(query.getMaxResults());
             for (QueryType.QueryAttribute attribute : query.getQueryAttribute()) {
                 QueryAttribute.Builder attributeBuilder = QueryAttribute
                         .builder(attribute.getName())

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/query/Invocation.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/query/Invocation.java
@@ -26,7 +26,6 @@ import org.jmxtrans.core.log.Logger;
 import org.jmxtrans.core.log.LoggerFactory;
 import org.jmxtrans.core.results.QueryResult;
 import org.jmxtrans.utils.time.Clock;
-import org.jmxtrans.utils.time.SystemClock;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
@@ -69,7 +68,7 @@ public class Invocation {
             @Nonnull Object[] params,
             @Nonnull String[] signature,
             @Nonnull String resultAlias,
-            @Nonnull SystemClock clock) {
+            @Nonnull Clock clock) {
         try {
             this.objectName = new ObjectName(objectName);
         } catch (MalformedObjectNameException e) {

--- a/jmxtrans2-core/src/main/xsd/jmxtrans.xsd
+++ b/jmxtrans2-core/src/main/xsd/jmxtrans.xsd
@@ -113,6 +113,7 @@
         </xs:sequence>
         <xs:attribute name="objectName" type="xs:string" use="required"/>
         <xs:attribute name="resultAlias" type="xs:string"/>
+        <xs:attribute name="maxResults" type="xs:int" default="50"/>
     </xs:complexType>
 
     <xs:complexType name="invocationType">
@@ -127,6 +128,7 @@
         <xs:attribute name="objectName" type="xs:string" use="required"/>
         <xs:attribute name="operationName" type="xs:string" use="required"/>
         <xs:attribute name="resultAlias" type="xs:string"/>
+        <xs:attribute name="maxResults" type="xs:int" default="50"/>
     </xs:complexType>
 
     <xs:complexType name="outputWriterType">

--- a/jmxtrans2-core/src/test/java/org/jmxtrans/core/config/XmlConfigParserTest.java
+++ b/jmxtrans2-core/src/test/java/org/jmxtrans/core/config/XmlConfigParserTest.java
@@ -23,6 +23,7 @@
 package org.jmxtrans.core.config;
 
 import org.jmxtrans.core.query.Invocation;
+import org.jmxtrans.core.query.embedded.Query;
 import org.jmxtrans.core.query.embedded.Server;
 import org.jmxtrans.utils.PropertyPlaceholderResolver;
 import org.jmxtrans.utils.io.Resource;
@@ -71,6 +72,22 @@ public class XmlConfigParserTest {
         assertThat(configuration.getPeriod()).isEqualTo(new Interval(10, SECONDS));
     }
 
+    @Test
+    public void maxResultIsSetForQueries() throws IllegalAccessException, IOException, JAXBException, InstantiationException, SAXException, ClassNotFoundException {
+        Resource resource = new StandardResource("classpath:org/jmxtrans/core/config/max-result-query.xml");
+        Configuration configuration = parser.parseConfiguration(resource);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration.getServers()).hasSize(1);
+        Server server = configuration.getServers().iterator().next();
+        assertThat(server.getQueries()).hasSize(2);
+        Iterator<Query> queryIterator = server.getQueries().iterator();
+        Query query1 = queryIterator.next();
+        Query query2 = queryIterator.next();
+
+        assertThat(query1.getMaxResults()).isEqualTo(50);
+        assertThat(query2.getMaxResults()).isEqualTo(10);
+    }
+    
     @Test
     public void serversAreParsed() throws Exception {
         Resource resource = new StandardResource("classpath:org/jmxtrans/core/config/with-servers.xml");

--- a/jmxtrans2-core/src/test/java/org/jmxtrans/core/query/embedded/QueryTest.java
+++ b/jmxtrans2-core/src/test/java/org/jmxtrans/core/query/embedded/QueryTest.java
@@ -92,8 +92,8 @@ public class QueryTest {
         Query query = Query.builder()
                 .withObjectName("test:type=MemoryPool,name=PS Perm Gen")
                 .addAttribute(QueryAttribute.builder("Usage")
-                    .withKeys(asList("committed", "init", "max", "used"))
-                    .build())
+                        .withKeys(asList("committed", "init", "max", "used"))
+                        .build())
                 .build();
         Iterable<QueryResult> results = query.collectMetrics(mbeanServer, new ResultNameStrategy());
         assertThat(results).hasSize(4);
@@ -105,6 +105,21 @@ public class QueryTest {
 
         QueryResult result2 = queryResultIterator.next();
         assertThat(result2.getValue()).isInstanceOf(Number.class);
+    }
+
+    @Test
+    public void maxResultsIsHonored() throws Exception {
+        Query query = Query.builder()
+                .withObjectName("test:type=MemoryPool,name=PS Perm Gen")
+                .withMaxResults(2)
+                .addAttribute(QueryAttribute.builder("Usage")
+                        .withKeys(asList("committed", "init", "max", "used"))
+                        .build())
+                .build();
+
+        Iterable<QueryResult> results = query.collectMetrics(mbeanServer, new ResultNameStrategy());
+
+        assertThat(results).hasSize(2);
     }
 
     @Test

--- a/jmxtrans2-core/src/test/resources/org/jmxtrans/core/config/max-result-query.xml
+++ b/jmxtrans2-core/src/test/resources/org/jmxtrans/core/config/max-result-query.xml
@@ -28,26 +28,7 @@
 
     <queries>
         <query objectName="java.lang:type=MemoryPool,name=PS Eden Space" resultAlias="eden"/>
-        <query objectName="java.lang:type=MemoryPool,name=PS Perm Gen" resultAlias="permgen">
-            <queryAttribute name="CollectionUsageThresholdCount"/>
-        </query>
-        <query objectName="java.lang:type=MemoryPool,name=PS Perm Gen" resultAlias="permgen">
-            <queryAttribute name="PeakUsage" resultAlias="peak">
-                <key>used</key>
-            </queryAttribute>
-        </query>
+        <query objectName="java.lang:type=MemoryPool,name=PS Perm Gen" resultAlias="permgen" maxResults="10"/>
     </queries>
-
-    <invocations>
-        <invocation objectName="java.lang:type=Memory" operationName="gc" resultAlias="jvm.gc"/>
-        <invocation objectName="java.lang:type=Threading" operationName="getThreadCpuTime" resultAlias="jvm.thread.cpu">
-            <parameter value="1" type="long"/>
-        </invocation>
-    </invocations>
-
-    <outputWriters>
-        <outputWriter class="org.jmxtrans.core.config.DummyOutputWriter"/>
-        <outputWriter class="org.jmxtrans.core.output.DevNullOutputWriter" unkownSetting="unused-value"/>
-    </outputWriters>
 
 </jmxtrans>

--- a/pom.xml
+++ b/pom.xml
@@ -610,6 +610,9 @@
                         <rules>
                             <rule>
                                 <element>PACKAGE</element>
+                                <excludes>
+                                    <exclude>org.jmxtrans.core.config.jaxb*</exclude>
+                                </excludes>
                                 <limits>
                                     <limit>
                                         <counter>LINE</counter>


### PR DESCRIPTION
Configuration format updated to allow overriding this default.