### PR TITLE
optional and provided dependencies are now excluded from shaded jar to fix #39

### DIFF
--- a/jmxtrans2-agent/pom.xml
+++ b/jmxtrans2-agent/pom.xml
@@ -45,10 +45,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jmxtrans.jmxtrans2</groupId>
             <artifactId>jmxtrans2-core</artifactId>
         </dependency>
@@ -64,6 +60,11 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,7 @@
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>3.0.0</version>
+                <optional>true</optional>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -562,6 +563,15 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>2.3</version>
+                    <configuration>
+                        <artifactSet>
+                            <excludes>
+                                <exclude>com.google.code.findbugs:annotations</exclude>
+                                <exclude>com.google.code.findbugs:jsr305</exclude>
+                            </excludes>
+                        </artifactSet>
+                        <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Note that I have not found a clean way to exclude all dependencies with optional scope, so findbugs and JSR305 annotations are excluded explicitly.