### PR TITLE
Implement a fast build profile.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -611,6 +611,7 @@
                     </configuration>
                     <executions>
                         <execution>
+                            <id>findbugs</id>
                             <goals>
                                 <goal>check</goal>
                             </goals>
@@ -988,6 +989,34 @@
                                         </resource>
                                     </resources>
                                 </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>fastBuild</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>findbugs</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-maven</artifactId>
+                        <executions>
+                            <execution>
+                                <id>pitest</id>
+                                <phase>none</phase>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
The "fastBuild" profile disable findbugs and pitest. This makes the build significantly faster. We could disable other functionnalities in the future if required.

This fixes #23.