### PR TITLE
Introduce a central ObjectNameFactory to ensure MBeans are named in a coherent fashion.

### DIFF
--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/monitoring/ObjectNameFactory.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/monitoring/ObjectNameFactory.java
@@ -1,0 +1,55 @@
+/**
+ * The MIT License
+ * Copyright (c) 2014 JMXTrans Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jmxtrans.core.monitoring;
+
+import java.util.Hashtable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+@ThreadSafe
+public class ObjectNameFactory {
+
+    @Nonnull private static final String DOMAIN = "org.jmxtrans";
+    @Nonnull private final String type;
+    @Nonnull private final AtomicInteger idSequence = new AtomicInteger();
+
+    public ObjectNameFactory(@Nonnull String type) {
+        this.type = type;
+    }
+    
+    public ObjectName create(String name) throws MalformedObjectNameException {
+        Hashtable<String, String> properties = new Hashtable<>();
+        properties.put("id", type + "-" + idSequence.getAndIncrement());
+        properties.put("type", type);
+        properties.put("name", name
+                .replaceAll(":", "|")
+                .replaceAll("=", "-")
+                .replaceAll(",", ".")
+                .replaceAll(" ", "_"));
+        return ObjectName.getInstance(DOMAIN, properties);
+    }
+}

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/query/Query.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/query/Query.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -42,6 +41,7 @@ import javax.management.ObjectName;
 
 import org.jmxtrans.core.log.Logger;
 import org.jmxtrans.core.log.LoggerFactory;
+import org.jmxtrans.core.monitoring.ObjectNameFactory;
 import org.jmxtrans.core.monitoring.SelfNamedMBean;
 import org.jmxtrans.core.results.QueryResult;
 import org.jmxtrans.utils.time.Clock;
@@ -207,7 +207,7 @@ public class Query implements QueryMBean, SelfNamedMBean {
     }
 
     public static final class Builder {
-        @Nonnull private static final AtomicInteger queryIdSequence = new AtomicInteger();
+        @Nonnull private static final ObjectNameFactory objectNameFactory = new ObjectNameFactory("query");
 
         @Nullable private ObjectName objectName;
         @Nullable private String resultAlias;
@@ -269,7 +269,7 @@ public class Query implements QueryMBean, SelfNamedMBean {
                         objectName,
                         resultAlias,
                         attributes,
-                        new ObjectName("org.jmxtrans.query:Type=Query,id=" + queryIdSequence.incrementAndGet()),
+                        objectNameFactory.create(objectName.toString()),
                         maxResults,
                         new QueryMetrics(clock)
                 );

--- a/jmxtrans2-core/src/test/java/org/jmxtrans/core/config/XmlConfigParserTest.java
+++ b/jmxtrans2-core/src/test/java/org/jmxtrans/core/config/XmlConfigParserTest.java
@@ -30,6 +30,7 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.UnmarshalException;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.jmxtrans.core.monitoring.ObjectNameFactory;
 import org.jmxtrans.core.query.Invocation;
 import org.jmxtrans.core.query.Query;
 import org.jmxtrans.core.query.Server;
@@ -55,7 +56,8 @@ public class XmlConfigParserTest {
     public void createConfigurationParser() throws JAXBException, ParserConfigurationException, IOException, SAXException {
         parser = XmlConfigParser.newInstance(
                 new PropertyPlaceholderResolverXmlPreprocessor(new PropertyPlaceholderResolver()),
-                new SystemClock());
+                new SystemClock(),
+                new ObjectNameFactory("outputWriter"));
     }
 
     @Test(expectedExceptions = UnmarshalException.class)

--- a/jmxtrans2-core/src/test/java/org/jmxtrans/core/monitoring/ObjectNameFactoryTest.java
+++ b/jmxtrans2-core/src/test/java/org/jmxtrans/core/monitoring/ObjectNameFactoryTest.java
@@ -1,0 +1,58 @@
+/**
+ * The MIT License
+ * Copyright (c) 2014 JMXTrans Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jmxtrans.core.monitoring;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObjectNameFactoryTest {
+
+    @Test
+    public void objectNameIsCreatedWithAppropriateParams() throws MalformedObjectNameException {
+        ObjectName objectName = new ObjectNameFactory("query").create("myQuery");
+
+        assertThat(objectName.getDomain()).isEqualTo("org.jmxtrans");
+        assertThat(objectName.getKeyProperty("id")).isEqualTo("query-0");
+        assertThat(objectName.getKeyProperty("name")).isEqualTo("myQuery");
+        assertThat(objectName.getKeyProperty("type")).isEqualTo("query");
+    }
+
+    @Test
+    public void idIsIncrementedAtEachObjectCreation() throws MalformedObjectNameException {
+        ObjectNameFactory objectNameFactory = new ObjectNameFactory("query");
+        
+        assertThat(objectNameFactory.create("myQuery").getKeyProperty("id")).isEqualTo("query-0");
+        assertThat(objectNameFactory.create("myOtherQuery").getKeyProperty("id")).isEqualTo("query-1");
+    }
+    
+    @Test
+    public void objectNameIsAValidName() throws MalformedObjectNameException {
+        ObjectNameFactory objectNameFactory = new ObjectNameFactory("query");
+        
+        objectNameFactory.create("test:type=*,name=PS Eden Space");
+    }
+}


### PR DESCRIPTION
This fixes #46 by using the object name of the bean monitored by a query as the object name representing the query.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans2/pull/72?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans2/pull/72'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>