### PR TITLE
Better default names for jmx metrics

### DIFF
--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/query/ResultNameStrategy.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/query/ResultNameStrategy.java
@@ -137,10 +137,25 @@ public class ResultNameStrategy {
         StringBuilder result = new StringBuilder();
         stringEscape.escape(objectName.getDomain(), result);
         result.append('.');
+
         List<String> keys = list(objectName.getKeyPropertyList().keys());
         sort(keys);
+
+        // Treat "type" and "name" attributes in special way:
+        // do not write key, only values. This will result in metric like "java.lang.Memory" instead of "java.lang.type__Memory"
+        String type = objectName.getKeyProperty("type");
+        String name = objectName.getKeyProperty("name");
+        if(type != null && type.length() > 0)
+            result.append(type);
+        if(name != null && name.length()> 0)
+            result.append(name);
+
         for (Iterator<String> it = keys.iterator(); it.hasNext(); ) {
             String key = it.next();
+            if(key.equalsIgnoreCase("type") || key.equalsIgnoreCase("name"))
+                continue;
+
+            result.append('.');
             stringEscape.escape(key, result);
             result.append("__");
             stringEscape.escape(objectName.getKeyProperty(key), result);

--- a/jmxtrans2-core/src/test/java/org/jmxtrans/core/query/ResultNameStrategyTest.java
+++ b/jmxtrans2-core/src/test/java/org/jmxtrans/core/query/ResultNameStrategyTest.java
@@ -1,0 +1,51 @@
+package org.jmxtrans.core.query;
+
+import java.util.Hashtable;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.jmxtrans.utils.mockito.MockitoTestNGListener;
+
+import org.mockito.Mock;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Listeners(MockitoTestNGListener.class)
+public class ResultNameStrategyTest {
+
+    @Mock private Query query;
+
+    private ResultNameStrategy resultNameStrategy;
+
+    @BeforeMethod
+    public void initResultNameStrategy() {
+        resultNameStrategy = new ResultNameStrategy();
+    }
+
+    @Test
+    public void defaultMetricNameIsTypeAndName() throws MalformedObjectNameException {
+        Hashtable<String, String> properties = new Hashtable<>();
+        properties.put("type", "BufferPool");
+        properties.put("name", "direct");
+        ObjectName objectName = new ObjectName("java.nio", properties);
+
+        assertThat(resultNameStrategy.getResultName(query, objectName, QueryAttribute.builder("Count").build()))
+                .isEqualTo("java.nio.BufferPool.direct.Count");
+    }
+
+    @Test
+    public void defaultMetricNameIsTypeAndNameAndOtherAttributes() throws MalformedObjectNameException {
+        Hashtable<String, String> properties = new Hashtable<>();
+        properties.put("type", "BufferPool");
+        properties.put("name", "direct");
+        properties.put("other", "value");
+        ObjectName objectName = new ObjectName("java.nio", properties);
+
+        assertThat(resultNameStrategy.getResultName(query, objectName, QueryAttribute.builder("Count").build()))
+                .isEqualTo("java.nio.BufferPool.direct.other__value.Count");
+    }
+}


### PR DESCRIPTION
Default names for metrics treat "type" and "name" attributes as they were not well known.
First, it is preferred to see something like  "java.nio.BufferPool.direct" instead of "java.nio.name__direct.type__BufferPool,". Second, because of keys sorting, "name" attribute will go into the label before "type" which contradict to implicit agreement that names are grouped under types.

This patch treats "name" and "type" attributes in special way, while leaving other attributes (if any) with previous rendering "key__value".
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans2/pull/74%23issuecomment-83737354%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans2/pull/74%23issuecomment-83742819%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans2/pull/74%23issuecomment-84134202%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans2/pull/74%23issuecomment-84143731%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans2/pull/74%23issuecomment-84329199%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans2/pull/74%23issuecomment-84333473%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans2/pull/74%23issuecomment-84351602%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans2/pull/74%23issuecomment-83737354%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20good.%20It%20probably%20misses%20a%20unit%20test%20to%20document%20the%20behaviour%20...%22%2C%20%22created_at%22%3A%20%222015-03-19T19%3A50%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Minimal%20code%20coverage%20not%20met%2C%20I%27m%20going%20to%20need%20a%20test%20before%20merge.%20If%20you%20have%20time%20to%20write%20the%20test%2C%20that%20would%20be%20welcomed%2C%20otherwise%20I%27ll%20have%20a%20look%20into%20it%20this%20weekend.%22%2C%20%22created_at%22%3A%20%222015-03-19T20%3A05%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20familiar%20with%20github%20workflow%2C%20and%20it%20created%20another%20pool%20request.%20Is%20it%20the%20right%20thing%2C%20or%20should%20I%20have%20continue%20this%20one%20somehow%3F%22%2C%20%22created_at%22%3A%20%222015-03-20T20%3A19%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/106474%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/vchekan%22%7D%7D%2C%20%7B%22body%22%3A%20%22According%20to%20my%20understanding%3A%5Cr%5Cn%5Cr%5Cn%2A%20merge%20my%20pull%20request%20into%20your%20branch%20%28just%20like%20you%20did%29%5Cr%5Cn%2A%20update%20your%20local%20copy%20%28%60git%20pull%20--rebase%60%20or%20similar%29%5Cr%5Cn%2A%20add%20more%20changes%20to%20your%20local%20branch%20%28fixing%20the%20tests%2C%20just%20like%20you%20did%29%5Cr%5Cn%2A%20push%20this%20same%20branch%20to%20GitHub%20%28no%20need%20to%20create%20a%20new%20branch%2C%20this%20will%20automatically%20update%20the%20pull%20request%29%5Cr%5Cn%5Cr%5CnAnother%20option%20could%20be%20to%20merge%20my%20PR%2C%20correct%20the%20tests%2C%20and%20before%20pushing%20the%20changes%2C%20squash%20all%20the%20commits%20into%20a%20single%20change%20%28if%20all%20those%20incremental%20commits%20do%20not%20add%20to%20the%20comprehension%20of%20the%20history%29.%22%2C%20%22created_at%22%3A%20%222015-03-20T21%3A00%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20it%27s%20OK%20for%20you%2C%20I%20will%20squash%20all%20commits%20and%20merge%20your%20work%20to%20master.%20That%20will%20put%20me%20as%20the%20committer%20of%20your%20changes.%20If%20you%20want%20to%20keep%20attribution%2C%20could%20you%20accept%20https%3A//github.com/ntent-ad/jmxtrans2/pull/2%20and%20squash%20all%20commits%20on%20your%20side%20%3F%20And%20then%20sent%20a%20PR%20to%20merge%20this%20to%20master%20%3F%5Cr%5Cn%5Cr%5CnIn%20any%20case%2C%20thanks%20a%20lot%20for%20the%20help%20%21%22%2C%20%22created_at%22%3A%20%222015-03-21T12%3A33%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Actually%2C%20the%20rebase%20kept%20you%20as%20author.%20See%20%2377%20and%20let%20me%20know%20if%20you%20think%20it%20is%20ok%20to%20merge%20it.%22%2C%20%22created_at%22%3A%20%222015-03-21T13%3A19%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Replaced%20by%20%2374%20%22%2C%20%22created_at%22%3A%20%222015-03-21T14%3A17%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans2/pull/74#issuecomment-83737354'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Looks good. It probably misses a unit test to document the behaviour ...
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Minimal code coverage not met, I'm going to need a test before merge. If you have time to write the test, that would be welcomed, otherwise I'll have a look into it this weekend.
- <a href='https://github.com/vchekan'><img border=0 src='https://avatars.githubusercontent.com/u/106474?v=3' height=16 width=16'></a> I'm not familiar with github workflow, and it created another pool request. Is it the right thing, or should I have continue this one somehow?
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> According to my understanding:
* merge my pull request into your branch (just like you did)
* update your local copy (`git pull --rebase` or similar)
* add more changes to your local branch (fixing the tests, just like you did)
* push this same branch to GitHub (no need to create a new branch, this will automatically update the pull request)
Another option could be to merge my PR, correct the tests, and before pushing the changes, squash all the commits into a single change (if all those incremental commits do not add to the comprehension of the history).
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> If it's OK for you, I will squash all commits and merge your work to master. That will put me as the committer of your changes. If you want to keep attribution, could you accept https://github.com/ntent-ad/jmxtrans2/pull/2 and squash all commits on your side ? And then sent a PR to merge this to master ?
In any case, thanks a lot for the help !
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Actually, the rebase kept you as author. See #77 and let me know if you think it is ok to merge it.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Replaced by #74


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans2/pull/74?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans2/pull/74?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans2/pull/74'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>