### PR TITLE
Better default name for metrics

### DIFF
--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/query/ResultNameStrategy.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/query/ResultNameStrategy.java
@@ -136,17 +136,33 @@ public class ResultNameStrategy {
     private String escapeObjectName(@Nonnull ObjectName objectName) {
         StringBuilder result = new StringBuilder();
         stringEscape.escape(objectName.getDomain(), result);
-        result.append('.');
+
         List<String> keys = list(objectName.getKeyPropertyList().keys());
         sort(keys);
+
+        // Treat "type" and "name" attributes in special way:
+        // do not write key, only values. This will result in metric like "java.lang.Memory" instead of "java.lang.type__Memory"
+        String type = objectName.getKeyProperty("type");
+        String name = objectName.getKeyProperty("name");
+
+        if(type != null && type.length() > 0) {
+            result.append('.');
+            result.append(type);
+        }
+        if(name != null && name.length()> 0) {
+            result.append('.');
+            result.append(name);
+        }
+
         for (Iterator<String> it = keys.iterator(); it.hasNext(); ) {
             String key = it.next();
+            if(key.equalsIgnoreCase("type") || key.equalsIgnoreCase("name"))
+                continue;
+
+            result.append('.');
             stringEscape.escape(key, result);
             result.append("__");
             stringEscape.escape(objectName.getKeyProperty(key), result);
-            if (it.hasNext()) {
-                result.append('.');
-            }
         }
         logger.debug(format("escapeObjectName(%s): %s", objectName, result));
         return result.toString();

--- a/jmxtrans2-core/src/test/java/org/jmxtrans/core/query/ResultNameStrategyTest.java
+++ b/jmxtrans2-core/src/test/java/org/jmxtrans/core/query/ResultNameStrategyTest.java
@@ -1,0 +1,83 @@
+/**
+ * The MIT License
+ * Copyright (c) 2014 JMXTrans Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jmxtrans.core.query;
+
+import java.util.Hashtable;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.jmxtrans.utils.mockito.MockitoTestNGListener;
+
+import org.mockito.Mock;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Listeners(MockitoTestNGListener.class)
+public class ResultNameStrategyTest {
+
+    @Mock private Query query;
+
+    private ResultNameStrategy resultNameStrategy;
+
+    @BeforeMethod
+    public void initResultNameStrategy() {
+        resultNameStrategy = new ResultNameStrategy();
+    }
+
+    @Test
+    public void defaultMetricNameIsTypeAndName() throws MalformedObjectNameException {
+        Hashtable<String, String> properties = new Hashtable<>();
+        properties.put("type", "BufferPool");
+        properties.put("name", "direct");
+        ObjectName objectName = new ObjectName("java.nio", properties);
+
+        assertThat(resultNameStrategy.getResultName(query, objectName, QueryAttribute.builder("Count").build()))
+                .isEqualTo("java.nio.BufferPool.direct.Count");
+    }
+
+    @Test
+    public void defaultMetricNameIsTypeAndNameAndOtherAttributes() throws MalformedObjectNameException {
+        Hashtable<String, String> properties = new Hashtable<>();
+        properties.put("type", "BufferPool");
+        properties.put("name", "direct");
+        properties.put("other", "value");
+        ObjectName objectName = new ObjectName("java.nio", properties);
+
+        assertThat(resultNameStrategy.getResultName(query, objectName, QueryAttribute.builder("Count").build()))
+                .isEqualTo("java.nio.BufferPool.direct.other__value.Count");
+    }
+
+    @Test
+    public void typeButNoNameAttribute() throws MalformedObjectNameException {
+        Hashtable<String, String> properties = new Hashtable<>();
+        properties.put("type", "Memory");
+        ObjectName objectName = new ObjectName("java.lang", properties);
+
+        assertThat(resultNameStrategy.getResultName(query, objectName, QueryAttribute.builder("ObjectPendingFinalizationCount").build()))
+                .isEqualTo("java.lang.Memory.ObjectPendingFinalizationCount");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,13 @@
                 <role>developer</role>
             </roles>
         </developer>
+        <developer>
+            <id>vchekan</id>
+            <name>Vadim Chekan</name>
+            <roles>
+                <role>contributor</role>
+            </roles>
+        </developer>
     </developers>
 
     <modules>


### PR DESCRIPTION
When there is no "resultAlias" configuration attribute, construct metric name as "java.lang.Memory" instead of "java.lang.type__Memory" and "java.nio.BufferPool.direct" instead of "java.nio.name__direct.type__BufferPool,".
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans2/pull/77?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans2/pull/77'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>