### PR TITLE
More robust test of date for different timezones

### DIFF
--- a/jmxtrans2-core/src/test/java/org/jmxtrans/core/log/PrintWriterLoggerTest.java
+++ b/jmxtrans2-core/src/test/java/org/jmxtrans/core/log/PrintWriterLoggerTest.java
@@ -25,6 +25,7 @@ package org.jmxtrans.core.log;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.util.regex.Pattern;
 
 import org.jmxtrans.utils.time.ManualClock;
 
@@ -46,6 +47,11 @@ import static org.jmxtrans.utils.io.Charsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class PrintWriterLoggerTest {
+
+    // To make the test valid in different timezones, only test the format of the date
+    // note that this will still fail for timezones which are not full hours of difference from UTC
+    // but let's assume that this is a corner case. We'll address that if the issue arises.
+    private static final Pattern DATE_TIME_PATTERN = compile(".*\\d{4}\\.\\d{2}\\.\\d{2} \\d{2}:16:40\\.000.*", DOTALL);
 
     private ManualClock clock = new ManualClock();
     private ByteArrayOutputStream byteArray;
@@ -123,7 +129,7 @@ public class PrintWriterLoggerTest {
                 .contains("testMessage")
                 .contains(DEBUG.toString())
                 .contains("testLogger")
-                .matches(compile(".*1970\\.01\\.01 ..:16:40\\.000.*", DOTALL)) // ignore hours to not test timezone
+                .matches(DATE_TIME_PATTERN)
                 .endsWith(lineSeparator());
     }
 
@@ -135,7 +141,7 @@ public class PrintWriterLoggerTest {
                 .contains("testMessage")
                 .contains(DEBUG.toString())
                 .contains("testLogger")
-                .matches(compile(".*1970\\.01\\.01 ..:16:40\\.000.*", DOTALL)) // ignore hours to not test timezone
+                .matches(DATE_TIME_PATTERN)
                 .contains("myException")
                 .endsWith(lineSeparator());
     }


### PR DESCRIPTION
For different timezones, dates can actually shift over to the next day. So let's only test for the format of the date. Minutes and seconds should still be the same for other timezones, so let's keep this check. Note that for timezone having an offset from UTC which is not a full hour, this might still fail. We'll address this if the problem actually arises.

Side note: I'm always amazed at how simple time looks, but how complex it really is ...

This fixes #75.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans2/pull/78?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans2/pull/78'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>