### PR TITLE
Introduced stormpot as object pool

### DIFF
--- a/jmxtrans2-agent/pom.xml
+++ b/jmxtrans2-agent/pom.xml
@@ -126,6 +126,12 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>stormpot</pattern>
+                                    <shadedPattern>org.jmxtrans.shaded.stormpot</shadedPattern>
+                                </relocation>
+                            </relocations>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>all</shadedClassifierName>
                             <transformers>

--- a/jmxtrans2-core/pom.xml
+++ b/jmxtrans2-core/pom.xml
@@ -42,6 +42,10 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.github.chrisvest</groupId>
+            <artifactId>stormpot</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jmxtrans.jmxtrans2</groupId>
             <artifactId>jmxtrans2-utils</artifactId>
         </dependency>

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/DevNullOutputWriter.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/DevNullOutputWriter.java
@@ -36,14 +36,14 @@ import org.jmxtrans.core.results.QueryResult;
 public class DevNullOutputWriter implements OutputWriter {
 
     @Override
-    public int write(QueryResult result) throws IOException {
+    public int write(@Nonnull QueryResult result) throws IOException {
         return 0;
     }
 
     public static final class Factory implements OutputWriterFactory<DevNullOutputWriter> {
         @Nonnull
         @Override
-        public DevNullOutputWriter create(Map<String, String> settings) {
+        public DevNullOutputWriter create(@Nonnull Map<String, String> settings) {
             return new DevNullOutputWriter();
         }
     }

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/MetricCollectingOutputWriter.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/MetricCollectingOutputWriter.java
@@ -55,7 +55,7 @@ public class MetricCollectingOutputWriter implements OutputWriter, MetricCollect
     }
     
     @Override
-    public int write(@Nonnull QueryResult result) throws IOException {
+    public int write(@Nonnull QueryResult result) throws IOException, InterruptedException {
         try (NanoChronometer chronometer = getProcessingTimeChronometer()) {
             int count = delegate.write(result);
             processedCount.addAndGet(count);

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/OutputWriter.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/OutputWriter.java
@@ -37,6 +37,6 @@ public interface OutputWriter {
      * @return the number of results actually processed
      */
     @CheckReturnValue
-    int write(@Nonnull QueryResult result) throws IOException;
+    int write(@Nonnull QueryResult result) throws IOException, InterruptedException;
 
 }

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/support/AppenderBasedOutputWriter.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/support/AppenderBasedOutputWriter.java
@@ -23,14 +23,13 @@
 package org.jmxtrans.core.output.support;
 
 import java.io.IOException;
-import java.io.Writer;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 
 import org.jmxtrans.core.results.QueryResult;
 
-public interface WriterBasedOutputWriter {
+public interface AppenderBasedOutputWriter {
     @CheckReturnValue
-    int write(@Nonnull Writer writer, @Nonnull QueryResult result) throws IOException;
+    int write(@Nonnull Appendable writer, @Nonnull QueryResult result) throws IOException;
 }

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/support/BatchingOutputWriter.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/support/BatchingOutputWriter.java
@@ -88,6 +88,8 @@ public class BatchingOutputWriter<T extends BatchedOutputWriter> implements Outp
                     counter += outputWriter.write(result);
                 } catch (IOException ioe) {
                     logger.warn(format("Error writing result [%s] to output writer [%s].", result, outputWriter), ioe);
+                } catch (InterruptedException e) {
+                    logger.warn(format("Writer interrupted while writing result [%s] to output writer [%s].", result, outputWriter), e);
                 }
             }
         } finally {

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/support/MinimalFormatOutputWriter.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/support/MinimalFormatOutputWriter.java
@@ -23,7 +23,6 @@
 package org.jmxtrans.core.output.support;
 
 import java.io.IOException;
-import java.io.Writer;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
@@ -34,16 +33,16 @@ import org.jmxtrans.core.results.QueryResult;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @ThreadSafe
-public class MinimalFormatOutputWriter implements WriterBasedOutputWriter {
+public class MinimalFormatOutputWriter implements AppenderBasedOutputWriter {
     @Override
-    public int write(@Nonnull Writer writer, @Nonnull QueryResult result) throws IOException {
-        writer.write(result.getName());
-        writer.write(" ");
-        writer.write(Objects.toString(result.getValue()));
-        writer.write(" ");
-        writer.write(Long.toString(result.getEpoch(MILLISECONDS)));
-        writer.write("\n"); // Let's be platform agnostic and make sure we output the same format all the time by not
-                            // using System.lineSeparator()
+    public int write(@Nonnull Appendable writer, @Nonnull QueryResult result) throws IOException {
+        writer.append(result.getName());
+        writer.append(" ");
+        writer.append(Objects.toString(result.getValue()));
+        writer.append(" ");
+        writer.append(Long.toString(result.getEpoch(MILLISECONDS)));
+        writer.append("\n"); // Let's be platform agnostic and make sure we output the same format all the time by not
+                             // using System.lineSeparator()
         return 1;
     }
 }

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/support/pool/CompoundExpiration.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/support/pool/CompoundExpiration.java
@@ -20,37 +20,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.jmxtrans.core.output;
+package org.jmxtrans.core.output.support.pool;
 
-import java.io.IOException;
-import java.util.Map;
+import stormpot.Expiration;
+import stormpot.Poolable;
+import stormpot.SlotInfo;
 
-import org.jmxtrans.core.results.MetricType;
-import org.jmxtrans.core.results.QueryResult;
+public class CompoundExpiration<T extends Poolable> implements Expiration<T> {
 
-import org.testng.annotations.Test;
+    private final Expiration<T> firstExpiration;
+    private final Expiration<T> secondExpiration;
 
-import static java.util.Collections.emptyMap;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class DevNullOutputWriterTest {
-
-    @Test
-    public void writingResultsDoesNothing() throws IOException, InterruptedException {
-        OutputWriter outputWriter = new DevNullOutputWriter();
-        QueryResult result = new QueryResult("name", MetricType.UNKNOWN, "value", 0);
-
-        int processedMetricCount = outputWriter.write(result);
-        assertThat(processedMetricCount).isZero();
+    public CompoundExpiration(Expiration<T> firstExpiration, Expiration<T> secondExpiration) {
+        this.firstExpiration = firstExpiration;
+        this.secondExpiration = secondExpiration;
     }
 
-    @Test
-    public void factoryCanCreateOutputWriter() {
-        Map<String, String> settings = emptyMap();
-        OutputWriter outputWriter = new DevNullOutputWriter.Factory().create(settings);
-
-        assertThat(outputWriter).isNotNull();
+    @Override
+    public boolean hasExpired(SlotInfo<? extends T> slotInfo) throws Exception {
+        return firstExpiration.hasExpired(slotInfo)
+                || secondExpiration.hasExpired(slotInfo);
     }
-
 }

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/support/pool/JmxTransTimeSpreadExpiration.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/support/pool/JmxTransTimeSpreadExpiration.java
@@ -1,0 +1,117 @@
+/**
+ * The MIT License
+ * Copyright (c) 2014 JMXTrans Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jmxtrans.core.output.support.pool;
+
+import java.util.concurrent.TimeUnit;
+
+import stormpot.Expiration;
+import stormpot.Poolable;
+import stormpot.SlotInfo;
+
+/**
+ * This is the standard time based {@link Expiration}. It will invalidate
+ * objects based on about how long ago they were allocated.
+ *
+ * @author Chris Vest <mr.chrisvest@gmail.com>
+ * @since 2.2
+ */
+// TODO 3.0 make class final
+// FIXME: This class has been copied from stormpot and slightly modified. It should be replaced by upstream as soon as
+// https://github.com/chrisvest/stormpot/pull/95 is release. Probably with stormpot 2.4.
+public class JmxTransTimeSpreadExpiration<T extends Poolable> implements Expiration<T> {
+
+    private final long lowerBoundMillis;
+    private final long upperBoundMillis;
+    private final TimeUnit unit;
+
+    /**
+     * Construct a new Expiration that will invalidate objects that are older
+     * than the given lower bound, before they get older than the upper bound,
+     * in the given time unit.
+     *
+     * If the `lowerBound` is less than 1, the `upperBound` is less than the
+     * `lowerBound`, or the `unit` is `null`, then an
+     * {@link java.lang.IllegalArgumentException} will be thrown.
+     *
+     * @param lowerBound Poolables younger than this, in the given unit, are not
+     *                   considered expired. This value must be at least 1.
+     * @param upperBound Poolables older than this, in the given unit, are always
+     *                   considered expired. This value must be greater than the
+     *                   lowerBound.
+     * @param unit The {@link TimeUnit} of the bounds values. Never `null`.
+     */
+    public JmxTransTimeSpreadExpiration(
+            long lowerBound,
+            long upperBound,
+            TimeUnit unit) {
+        if (lowerBound < 1) {
+            throw new IllegalArgumentException(
+                    "The lower bound cannot be less than 1.");
+        }
+        if (upperBound <= lowerBound) {
+            throw new IllegalArgumentException(
+                    "The upper bound must be greater than the lower bound.");
+        }
+        if (unit == null) {
+            throw new IllegalArgumentException("The TimeUnit cannot be null.");
+        }
+        this.lowerBoundMillis = unit.toMillis(lowerBound);
+        this.upperBoundMillis = unit.toMillis(upperBound);
+        this.unit = unit;
+    }
+
+    /**
+     * Returns `true`, with uniformly increasing probability, if the
+     * {@link stormpot.Poolable} represented by the given {@link SlotInfo} is
+     * older than the lower bound, eventually returning `true` with
+     * 100% certainty when the age of the Poolable is equal to or greater than
+     * the upper bound.
+     *
+     * The uniformity of the random expiration holds regardless of how often a
+     * Poolable is checked. That is to say, checking a Poolable more times within
+     * an interval of time, does _not_ increase its chances of being
+     * declared expired.
+     */
+    @Override
+    public boolean hasExpired(SlotInfo<? extends T> info) {
+        long expirationAge = info.getStamp();
+        if (expirationAge == 0) {
+            long maxDelta = upperBoundMillis - lowerBoundMillis;
+            expirationAge = lowerBoundMillis + Math.abs(info.randomInt() % maxDelta);
+            info.setStamp(expirationAge);
+        }
+        long age = info.getAgeMillis();
+        return age >= expirationAge;
+    }
+
+    /**
+     * Produces a String representation of this TimeSpreadExpiration.
+     */
+    @Override
+    public String toString() {
+        long lower = unit.convert(lowerBoundMillis, TimeUnit.MILLISECONDS);
+        long upper = unit.convert(upperBoundMillis, TimeUnit.MILLISECONDS);
+        return "TimeSpreadExpiration(" + lower + " to " + upper + " " + unit + ")";
+    }
+
+}

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/support/pool/PoolableSocketAppender.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/support/pool/PoolableSocketAppender.java
@@ -1,0 +1,86 @@
+/**
+ * The MIT License
+ * Copyright (c) 2014 JMXTrans Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jmxtrans.core.output.support.pool;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.nio.charset.Charset;
+
+import javax.annotation.Nonnull;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import stormpot.Poolable;
+import stormpot.Slot;
+
+public class PoolableSocketAppender implements Poolable, Appendable {
+
+    @Nonnull private final Slot slot;
+    @Nonnull @Getter(AccessLevel.PACKAGE) private final Socket socket;
+    @Nonnull private final Writer writer;
+
+    public PoolableSocketAppender(
+            @Nonnull Slot slot,
+            @Nonnull Charset charset,
+            @Nonnull SocketAddress serverAddress,
+            int socketTimeoutMillis) throws IOException {
+        this.slot = slot;
+        this.socket = new Socket();
+        socket.setKeepAlive(false);
+        socket.connect(serverAddress, socketTimeoutMillis);
+        this.writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), charset));
+    }
+
+    @Override
+    public void release() {
+        slot.release(this);
+    }
+
+    @Override
+    public Appendable append(CharSequence csq) throws IOException {
+        return writer.append(csq);
+    }
+
+    @Override
+    public Appendable append(CharSequence csq, int start, int end) throws IOException {
+        return writer.append(csq, start, end);
+    }
+
+    @Override
+    public Appendable append(char c) throws IOException {
+        return writer.append(c);
+    }
+
+    void close() throws IOException {
+        try(
+                Socket s = socket;
+                Writer w = writer
+                ) {
+            w.flush();
+        }
+    }
+}

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/support/pool/SocketAppenderValidator.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/support/pool/SocketAppenderValidator.java
@@ -20,37 +20,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.jmxtrans.core.output;
+package org.jmxtrans.core.output.support.pool;
 
-import java.io.IOException;
-import java.util.Map;
+import java.net.Socket;
 
-import org.jmxtrans.core.results.MetricType;
-import org.jmxtrans.core.results.QueryResult;
+import stormpot.Expiration;
+import stormpot.SlotInfo;
 
-import org.testng.annotations.Test;
-
-import static java.util.Collections.emptyMap;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class DevNullOutputWriterTest {
-
-    @Test
-    public void writingResultsDoesNothing() throws IOException, InterruptedException {
-        OutputWriter outputWriter = new DevNullOutputWriter();
-        QueryResult result = new QueryResult("name", MetricType.UNKNOWN, "value", 0);
-
-        int processedMetricCount = outputWriter.write(result);
-        assertThat(processedMetricCount).isZero();
+public class SocketAppenderValidator implements Expiration<PoolableSocketAppender> {
+    @Override
+    public boolean hasExpired(SlotInfo<? extends PoolableSocketAppender> slotInfo) throws Exception {
+        PoolableSocketAppender poolableSocketAppender = slotInfo.getPoolable();
+        Socket socket = poolableSocketAppender.getSocket();
+        return !socket.isConnected()
+                || !socket.isBound()
+                || socket.isClosed()
+                || socket.isInputShutdown()
+                || socket.isOutputShutdown();
     }
-
-    @Test
-    public void factoryCanCreateOutputWriter() {
-        Map<String, String> settings = emptyMap();
-        OutputWriter outputWriter = new DevNullOutputWriter.Factory().create(settings);
-
-        assertThat(outputWriter).isNotNull();
-    }
-
 }

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/writers/GraphiteOutputWriter.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/output/writers/GraphiteOutputWriter.java
@@ -23,7 +23,6 @@
 package org.jmxtrans.core.output.writers;
 
 import java.io.IOException;
-import java.io.Writer;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Objects;
@@ -32,14 +31,14 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
-import org.jmxtrans.core.output.support.WriterBasedOutputWriter;
+import org.jmxtrans.core.output.support.AppenderBasedOutputWriter;
 import org.jmxtrans.core.results.QueryResult;
 import org.jmxtrans.utils.VisibleForTesting;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 @ThreadSafe
-public class GraphiteOutputWriter implements WriterBasedOutputWriter {
+public class GraphiteOutputWriter implements AppenderBasedOutputWriter {
 
     @Nullable private volatile String metricPathPrefix;
 
@@ -47,13 +46,13 @@ public class GraphiteOutputWriter implements WriterBasedOutputWriter {
     GraphiteOutputWriter() {}
 
     @Override
-    public int write(@Nonnull Writer writer, @Nonnull QueryResult result) throws IOException {
-        writer.write(buildMetricPathPrefix());
-        writer.write(result.getName());
-        writer.write(" ");
-        writer.write(Objects.toString(result.getValue()));
-        writer.write(" ");
-        writer.write(Long.toString(result.getEpoch(SECONDS)));
+    public int write(@Nonnull Appendable writer, @Nonnull QueryResult result) throws IOException {
+        writer.append(buildMetricPathPrefix());
+        writer.append(result.getName());
+        writer.append(" ");
+        writer.append(Objects.toString(result.getValue()));
+        writer.append(" ");
+        writer.append(Long.toString(result.getEpoch(SECONDS)));
         return 1;
     }
 
@@ -62,10 +61,11 @@ public class GraphiteOutputWriter implements WriterBasedOutputWriter {
     private String buildMetricPathPrefix() {
         // {@link java.net.InetAddress#getLocalHost()} may not be known at JVM startup when the process is launched as a Linux service.
         // FIXME: there is a 5 second cache on localhost name, it probably make sense to reload it periodically. Hostname can change.
-        if (metricPathPrefix != null) return metricPathPrefix;
+        String result = metricPathPrefix;
+        if (result != null) return result;
 
-        metricPathPrefix = "servers." + getHostname() + ".";
-        return metricPathPrefix;
+        metricPathPrefix = result = "servers." + getHostname() + ".";
+        return result;
     }
 
     @Nonnull

--- a/jmxtrans2-core/src/main/java/org/jmxtrans/core/scheduler/ResultProcessor.java
+++ b/jmxtrans2-core/src/main/java/org/jmxtrans/core/scheduler/ResultProcessor.java
@@ -80,6 +80,8 @@ public class ResultProcessor {
             } catch (IOException e) {
                 logger.warn("Je suis Charlie");
                 logger.warn(format("Sadly, error while drawing [%s] to [%s].", result, outputWriter), e);
+            } catch (InterruptedException e) {
+                logger.warn(format("Writer has been interrupted [%s] to [%s].", result, outputWriter), e);
             } catch (Throwable t) {
                 logger.error(format("Error writing [%s] to [%s].", result, outputWriter));
                 throw t;

--- a/jmxtrans2-core/src/test/java/org/jmxtrans/core/config/DummyOutputWriter.java
+++ b/jmxtrans2-core/src/test/java/org/jmxtrans/core/config/DummyOutputWriter.java
@@ -34,7 +34,7 @@ import org.jmxtrans.core.results.QueryResult;
 public class DummyOutputWriter implements OutputWriter {
 
     @Override
-    public int write(QueryResult result) throws IOException {
+    public int write(@Nonnull QueryResult result) throws IOException {
         return 0;
     }
 

--- a/jmxtrans2-core/src/test/java/org/jmxtrans/core/output/MetricCollectingOutputWriterTest.java
+++ b/jmxtrans2-core/src/test/java/org/jmxtrans/core/output/MetricCollectingOutputWriterTest.java
@@ -60,14 +60,14 @@ public class MetricCollectingOutputWriterTest {
     }
     
     @Test
-    public void processedResultCountIsIncremented() throws IOException {
+    public void processedResultCountIsIncremented() throws IOException, InterruptedException {
         when(outputWriter.write(result)).thenReturn(1);
         metricCollectingOutputWriter.write(result);
         assertThat(metricCollectingOutputWriter.getProcessedResultsCount()).isEqualTo(1);
     }
     
     @Test
-    public void processingTimeIsCounted() throws IOException {
+    public void processingTimeIsCounted() throws IOException, InterruptedException {
         when(outputWriter.write(result)).then(new Answer<Integer>() {
             @Override
             public Integer answer(InvocationOnMock invocation) throws Throwable {
@@ -82,7 +82,7 @@ public class MetricCollectingOutputWriterTest {
     }
     
     @Test(expectedExceptions = IOException.class)
-    public void processingTimeIsCountedAlsoWhenExceptionIsThrown() throws IOException {
+    public void processingTimeIsCountedAlsoWhenExceptionIsThrown() throws IOException, InterruptedException {
         when(outputWriter.write(result)).then(new Answer<Integer>() {
             @Override
             public Integer answer(InvocationOnMock invocation) throws Throwable {

--- a/jmxtrans2-core/src/test/java/org/jmxtrans/core/output/support/BatchingOutputWriterTest.java
+++ b/jmxtrans2-core/src/test/java/org/jmxtrans/core/output/support/BatchingOutputWriterTest.java
@@ -50,15 +50,15 @@ public class BatchingOutputWriterTest {
     @Mock private QueryResult result;
 
     @BeforeMethod
-    public void setupBatchedOutputWriter() throws IOException {
+    public void setupBatchedOutputWriter() throws IOException, InterruptedException {
         when(targetOutputWriter.write(any(QueryResult.class)))
                 .thenReturn(1);
     }
     
     @Test
-    public void resultsAreNotWrittenWhenBatchSizeIsNotReached() throws IOException {
-        int processedResultCount = 0;
-        OutputWriter batchingOutputWriter = new BatchingOutputWriter(2, targetOutputWriter);
+    public void resultsAreNotWrittenWhenBatchSizeIsNotReached() throws IOException, InterruptedException {
+        int processedResultCount;
+        OutputWriter batchingOutputWriter = new BatchingOutputWriter<>(2, targetOutputWriter);
         
         processedResultCount = batchingOutputWriter.write(result);
         
@@ -73,9 +73,9 @@ public class BatchingOutputWriterTest {
     }
 
     @Test
-    public void resultsAreBatchedAtAppropriateSize() throws IOException {
-        int processedResultCount = 0;
-        OutputWriter batchingOutputWriter = new BatchingOutputWriter(2, targetOutputWriter);
+    public void resultsAreBatchedAtAppropriateSize() throws IOException, InterruptedException {
+        int processedResultCount;
+        OutputWriter batchingOutputWriter = new BatchingOutputWriter<>(2, targetOutputWriter);
         batchingOutputWriter.write(result);
         batchingOutputWriter.write(result);
         processedResultCount = batchingOutputWriter.write(result); // results are batched when the next result is received
@@ -84,9 +84,9 @@ public class BatchingOutputWriterTest {
     }
 
     @Test
-    public void beforeAndAfterBatchAreCalledInOrder() throws IOException {
+    public void beforeAndAfterBatchAreCalledInOrder() throws IOException, InterruptedException {
         InOrder inOrder = inOrder(targetOutputWriter);
-        OutputWriter batchingOutputWriter = new BatchingOutputWriter(1, targetOutputWriter);
+        OutputWriter batchingOutputWriter = new BatchingOutputWriter<>(1, targetOutputWriter);
         batchingOutputWriter.write(result);
         batchingOutputWriter.write(result);
         inOrder.verify(targetOutputWriter).beforeBatch();
@@ -95,7 +95,7 @@ public class BatchingOutputWriterTest {
     }
 
     @Test
-    public void resultsAreProcessedInOrder() throws IOException {
+    public void resultsAreProcessedInOrder() throws IOException, InterruptedException {
         InOrder inOrder = inOrder(targetOutputWriter);
 
         QueryResult result1 = new QueryResult("my.result", MetricType.UNKNOWN, 1, 1);
@@ -104,7 +104,7 @@ public class BatchingOutputWriterTest {
         QueryResult result4 = new QueryResult("my.result", MetricType.UNKNOWN, 1, 4);
         QueryResult result5 = new QueryResult("my.result", MetricType.UNKNOWN, 1, 5);
 
-        OutputWriter batchingOutputWriter = new BatchingOutputWriter(4, targetOutputWriter);
+        OutputWriter batchingOutputWriter = new BatchingOutputWriter<>(4, targetOutputWriter);
         batchingOutputWriter.write(result4);
         batchingOutputWriter.write(result5);
         batchingOutputWriter.write(result1);

--- a/jmxtrans2-core/src/test/java/org/jmxtrans/core/output/support/HttpOutputWriterTest.java
+++ b/jmxtrans2-core/src/test/java/org/jmxtrans/core/output/support/HttpOutputWriterTest.java
@@ -62,7 +62,7 @@ public class HttpOutputWriterTest {
     @Mock private OutputStreamBasedOutputWriter target;
     @Mock private QueryResult result;
 
-    @BeforeMethod
+    @BeforeClass
     public void initializeAppInfo() throws IOException {
         appInfo = AppInfo.load(AppInfo.class);
     }

--- a/jmxtrans2-core/src/test/java/org/jmxtrans/core/scheduler/ResultProcessorTest.java
+++ b/jmxtrans2-core/src/test/java/org/jmxtrans/core/scheduler/ResultProcessorTest.java
@@ -61,13 +61,13 @@ public class ResultProcessorTest {
     }
 
     @Test
-    public void resultsAreProcessed() throws IOException {
+    public void resultsAreProcessed() throws IOException, InterruptedException {
         resultProcessor.writeResult(1, result, outputWriter);
         verify(outputWriter).write(result);
     }
 
     @Test
-    public void exceptionsFromWriterAreManaged() throws IOException {
+    public void exceptionsFromWriterAreManaged() throws IOException, InterruptedException {
         doThrow(new IOException()).when(outputWriter).write(any(QueryResult.class));
         ResultProcessor.Processor processor = new ResultProcessor.Processor(clock, 10, result, outputWriter);
         processor.run();

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,11 @@
                 <version>2.5.3</version>
             </dependency>
             <dependency>
+                <groupId>com.github.chrisvest</groupId>
+                <artifactId>stormpot</artifactId>
+                <version>2.3</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>annotations</artifactId>
                 <version>3.0.0</version>


### PR DESCRIPTION
This includes some minor refactorings:

* TcpOutputWriter is not a BatchedOutputWriter anymore
* WriterBaedOutputWriter is now AppenderBasedOutputWriter to reduce the scope of what is required by client classes
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans2/pull/90?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans2/pull/90'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>